### PR TITLE
Update README to reflect changes to Auth0 Grant Types interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,13 @@ Starts the app without file watching
 3. Open the settings tab.
 4. Fill in the Name, Client type (Non Interactive Client), and the Allowed Callback URLs.
   - At this point setup your app's config file before continuing. (Check section below).
-5. Go to your `account settings` (top-right corner) and then click Advanced. Scroll down and enable `Enable APIs Section`.
-6. Go to `APIs` and select `Auth0 Management API`
-7. Go to `Non Interactive Client`, authorize your client, and select `read:users` scope.
-8. Click `Update` and it's all set.
+5. At `Token Endpoint Authentication Method` select `Post`.
+6. Scroll to the bottom of the page and select `Show Advanced Settings`.
+7. Under `Advanced Settings/Grant Types` check `Client Credentials` and click `Save Changes`.
+8. Go to your `account settings` (top-right corner) and then click Advanced. Scroll down and enable `Enable APIs Section`.
+9. Go to `APIs` and select `Auth0 Management API`
+10. Go to `Non Interactive Client`, authorize your client, and select `read:users` scope.
+11. Click `Update` and it's all set.
 
 ### Config
 


### PR DESCRIPTION
Auth0 has updated the Client and API creation interface.  It is now necessary to explicitly select the [Grant Types](https://auth0.com/docs/clients/client-grant-types) for the client to allow the API to make requests for Auth0 Client users.  I believe that there are other interface changes for Auth0 Management API as well.  I will investigate and submit an additional pull request for these.